### PR TITLE
add cargo-deny for license and advisory checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,9 @@ jobs:
 
       - name: Replay fixtures
         run: cargo run -q -p netform_cli --bin netform-replay-fixtures
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+
+      - name: cargo-deny
+        run: cargo deny check

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,23 @@
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "BSD-2-Clause",
+    "ISC",
+    "0BSD",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,7 @@ allow = [
     "BSD-2-Clause",
     "ISC",
     "0BSD",
+    "BSL-1.0",
     "Unicode-3.0",
     "Unicode-DFS-2016",
 ]


### PR DESCRIPTION
## What

Adds a `deny.toml` and a `cargo deny check` step to CI. Uses the same license allowlist and source restrictions as other cyberwitchery repos.

## Why

Catches license violations, known advisories, and unexpected crate sources in CI. Consistent with the setup in contextual-encoder, sbom-diff, unsafe-budget, and dd.

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._